### PR TITLE
JV15-210 Show available liquidity in USD on toggle

### DIFF
--- a/src/components/MarketTable.tsx
+++ b/src/components/MarketTable.tsx
@@ -163,7 +163,13 @@ export function MarketTable(): JSX.Element {
                         className="reserve-detail text-btn bold-text">
                         {pool.symbol} {dictionary.cockpit.detail}
                       </td>
-                      <td className="cell-border-right">{pool.vault.uiTokens}</td>
+                      <td className="cell-border-right">
+                        {currencyFormatter(
+                          nativeValues ? pool.vault.tokens : pool.vault.muln(pool.tokenPrice).tokens,
+                          !nativeValues,
+                          2
+                        )}
+                      </td>
                       <td>{`${(pool.depositApy * 100).toFixed(2)}%`}</td>
                       <td>{`${(pool.borrowApr * 100).toFixed(2)}%`}</td>
                       <td className="clickable-icon cell-border-right" onClick={() => setRadarOpen(true)}>


### PR DESCRIPTION
When toggling nativeValues to USD, show each pool's available liquidity in USD as well.

<img width="438" alt="Screenshot 2022-07-18 at 21 08 48" src="https://user-images.githubusercontent.com/32130807/179617704-180c2299-9b51-47e0-b05d-db76f2267f75.png">