### PR TITLE
fix liquidation modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "craco start",
     "start:legacy": "NODE_OPTIONS=--openssl-legacy-provider craco start",
     "debug": "cd ../jet-v2/libraries/ts && yarn build && npm link && cd ../../../jet-app && npm link @jet-lab/margin && npm run start",
+    "debug:legacy": "cd ../jet-v2/libraries/ts && yarn build && npm link && cd ../../../jet-app && npm link @jet-lab/margin && npm run start:legacy",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "prepare": "husky install",

--- a/src/components/LiquidationModal.tsx
+++ b/src/components/LiquidationModal.tsx
@@ -11,11 +11,11 @@ export function LiquidationModal(): JSX.Element {
   const { dictionary } = useLanguage();
   const { marginAccount } = useMargin();
   const { setCurrentAction } = useTradeContext();
-  const { open, setOpen, setClosed } = useLiquidationModal();
+  const { isDisplayed, setIsDisplayed } = useLiquidationModal();
   const requiredFunds = marginAccount?.poolPositions.USDC.liquidationEndingCollateral.tokens ?? 0;
   const { Title, Paragraph } = Typography;
 
-  if (marginAccount?.isBeingLiquidated && open) {
+  if (marginAccount?.isBeingLiquidated && isDisplayed) {
     return (
       <Modal visible className="liquidation-modal" footer={null} closable={false}>
         <Title type="danger">
@@ -43,8 +43,7 @@ export function LiquidationModal(): JSX.Element {
             size="small"
             onClick={() => {
               setCurrentAction('deposit');
-              setOpen(false);
-              setClosed(true);
+              setIsDisplayed(false);
             }}>
             {dictionary.cockpit.deposit}
           </Button>

--- a/src/components/MarketTable.tsx
+++ b/src/components/MarketTable.tsx
@@ -172,8 +172,8 @@ export function MarketTable(): JSX.Element {
                       </td>
                       <td>{`${(pool.depositApy * 100).toFixed(2)}%`}</td>
                       <td>{`${(pool.borrowApr * 100).toFixed(2)}%`}</td>
-                      <td className="clickable-icon cell-border-right" onClick={() => setRadarOpen(true)}>
-                        <RadarIcon width="18px" />
+                      <td className="clickable-icon cell-border-right">
+                        <RadarIcon width="18px" onClick={() => setRadarOpen(true)} />
                       </td>
                       <td
                         className={walletBalance ? 'user-wallet-value text-btn semi-bold-text' : ''}

--- a/src/contexts/LiquidationModal.tsx
+++ b/src/contexts/LiquidationModal.tsx
@@ -3,36 +3,29 @@ import { useMargin } from './marginContext';
 
 // Liquidation modal context
 interface LiquidationModal {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  closed: boolean;
-  setClosed: (closed: boolean) => void;
+  isDisplayed: boolean;
+  setIsDisplayed: (open: boolean) => void;
 }
 const LiquidationModalContext = createContext<LiquidationModal>({
-  open: false,
-  setOpen: () => null,
-  closed: false,
-  setClosed: () => null
+  isDisplayed: false,
+  setIsDisplayed: () => null
 });
 
 // Liquidation modal context provider
 export function LiquidationModalProvider(props: { children: any }): JSX.Element {
-  const [open, setOpen] = useState(false);
-  const [closed, setClosed] = useState(false);
+  const [isDisplayed, setIsDisplayed] = useState(false);
   const { marginAccount } = useMargin();
   useEffect(() => {
-    if (marginAccount?.isBeingLiquidated && !closed) {
-      setOpen(true);
+    if (marginAccount?.isBeingLiquidated && !isDisplayed) {
+      setIsDisplayed(true);
     }
-  }, [closed, marginAccount?.isBeingLiquidated]);
+  }, [isDisplayed, marginAccount?.isBeingLiquidated]);
 
   return (
     <LiquidationModalContext.Provider
       value={{
-        open,
-        setOpen,
-        closed,
-        setClosed
+        isDisplayed,
+        setIsDisplayed
       }}>
       {props.children}
     </LiquidationModalContext.Provider>


### PR DESCRIPTION
Liquidation modal won't pop up on new wallet connected
Make radar modal clicking more targeted to radar icon itself. I kept clicking on radar modal on accident. 