### PR TITLE
Add UI warning if risk level is above 1

### DIFF
--- a/src/components/TradePanel.tsx
+++ b/src/components/TradePanel.tsx
@@ -257,6 +257,13 @@ export function TradePanel(): JSX.Element {
             currencyFormatter(predictedRiskIndicator, false, 2)
           )
         );
+      } else if (predictedRiskIndicator > MarginAccount.RISK_LIQUIDATION_LEVEL) {
+        setInputError(
+          dictionary.cockpit.subjectToLiquidation.replaceAll(
+            '{{NEW-RISK}}',
+            currencyFormatter(predictedRiskIndicator, false, 2)
+          )
+        );
       }
       // Borrowing
     } else if (currentAction === 'borrow') {

--- a/src/components/TradePanel.tsx
+++ b/src/components/TradePanel.tsx
@@ -264,6 +264,7 @@ export function TradePanel(): JSX.Element {
             currencyFormatter(predictedRiskIndicator, false, 2)
           )
         );
+        setSendingTrade(false);
       }
       // Borrowing
     } else if (currentAction === 'borrow') {


### PR DESCRIPTION
If trade action causes risk level to be above 1, set UI warning about liquidation risk and disable sending trade.

<img width="900" alt="Screenshot 2022-07-28 at 15 49 36" src="https://user-images.githubusercontent.com/32130807/181581865-6e01f90a-a5d0-419b-9610-77fde42e7c5c.png">