### PR TITLE
JV15-272 Use shiftBy instead of setTo

### DIFF
--- a/src/components/TradePanel.tsx
+++ b/src/components/TradePanel.tsx
@@ -167,12 +167,17 @@ export function TradePanel(): JSX.Element {
       } else if (tradeAmount.gt(walletBalances[currentPool.symbol].amount)) {
         tradeError = dictionary.cockpit.notEnoughAsset.replaceAll('{{ASSET}}', currentPool.symbol);
         // Otherwise, send repay
+      } else if (tradeAmount.eq(walletBalances[currentPool.symbol].amount)) {
+        // If wallet balance equals trade amount,
+        // set repayAmount to be  tokens to shiftBy 0 
+        const repayAmount = PoolTokenChange.shiftBy(walletBalances[currentPool.symbol].amount)
+        res = await repay(currentPool.symbol, repayAmount);
       } else {
         // If user is repaying all, use loan notes
         const repayAmount =
           tradeAmount.tokens === accountPoolPosition.loanBalance.tokens
             ? PoolTokenChange.setTo(0)
-            : PoolTokenChange.shiftBy(accountPoolPosition.loanBalance.sub(tradeAmount));
+            : PoolTokenChange.setTo(accountPoolPosition.loanBalance.sub(tradeAmount));
         res = await repay(currentPool.symbol, repayAmount);
       }
     }

--- a/src/components/TradePanel.tsx
+++ b/src/components/TradePanel.tsx
@@ -172,7 +172,7 @@ export function TradePanel(): JSX.Element {
         const repayAmount =
           tradeAmount.tokens === accountPoolPosition.loanBalance.tokens
             ? PoolTokenChange.setTo(0)
-            : PoolTokenChange.setTo(accountPoolPosition.loanBalance.sub(tradeAmount));
+            : PoolTokenChange.shiftBy(accountPoolPosition.loanBalance.sub(tradeAmount));
         res = await repay(currentPool.symbol, repayAmount);
       }
     }

--- a/src/components/TradePanel.tsx
+++ b/src/components/TradePanel.tsx
@@ -169,8 +169,8 @@ export function TradePanel(): JSX.Element {
         // Otherwise, send repay
       } else if (tradeAmount.eq(walletBalances[currentPool.symbol].amount)) {
         // If wallet balance equals trade amount,
-        // set repayAmount to be  tokens to shiftBy 0 
-        const repayAmount = PoolTokenChange.shiftBy(walletBalances[currentPool.symbol].amount)
+        // set repayAmount to be  tokens to shiftBy 0
+        const repayAmount = PoolTokenChange.shiftBy(walletBalances[currentPool.symbol].amount);
         res = await repay(currentPool.symbol, repayAmount);
       } else {
         // If user is repaying all, use loan notes


### PR DESCRIPTION
When user is repaying max and repay amount is bounded by the maximum amount of tokens available in the wallet, if `tradeAmount` is the same as `walletBalance`, set repay amount to `shiftBy` wallet balance.

This prevents the insufficient funds error that occurs when using `setTo` in this instance.