### PR TITLE
Asset name styling

### DIFF
--- a/src/components/MarketTable.tsx
+++ b/src/components/MarketTable.tsx
@@ -167,10 +167,13 @@ export function MarketTable(): JSX.Element {
                       }}>
                       <td className="market-table-asset">
                         <AssetLogo symbol={String(pool.symbol)} height={25} />
-                        <span className="semi-bold-text">{pool.name}</span>
-                        <span>
-                          ≈{pool && pool.tokenPrice !== undefined ? currencyFormatter(pool.tokenPrice, true, 2) : '--'}
-                        </span>
+                        <div>
+                          <span className="semi-bold-text">{pool.name}</span>
+                          <span>
+                            ≈
+                            {pool && pool.tokenPrice !== undefined ? currencyFormatter(pool.tokenPrice, true, 2) : '--'}
+                          </span>
+                        </div>
                       </td>
                       <td
                         onClick={() => {

--- a/src/styles/App.less
+++ b/src/styles/App.less
@@ -1016,7 +1016,6 @@
                 span {
                   &:first-of-type {
                     top: 16px;
-                    white-space: nowrap;
                   }
                   &:last-of-type {
                     opacity: @disabled-opacity;
@@ -1283,6 +1282,35 @@
     }
     b {
       text-decoration: underline;
+    }
+  }
+}
+
+// Special handling for asset name overlap
+@media screen and (max-width: 1100px) {
+  .jet-app {
+    .market-table {
+      .table-container {
+        .market-table-asset {
+          height: 25px;
+          div {
+            display: flex;
+            flex-direction: column;
+          }
+          span {
+            position: relative !important;
+            transform: unset !important;
+            top: 0 !important;
+            &:first-of-type {
+              width: calc(100% - 45px);
+            }
+            &:last-of-type {
+              opacity: @disabled-opacity;
+              font-size: @sm-font-size;
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/styles/App.less
+++ b/src/styles/App.less
@@ -1016,6 +1016,7 @@
                 span {
                   &:first-of-type {
                     top: 16px;
+                    white-space: nowrap;
                   }
                   &:last-of-type {
                     opacity: @disabled-opacity;


### PR DESCRIPTION
Expand table row height and make asset names wrap below 1100px.

Before
![image](https://user-images.githubusercontent.com/32130807/183882036-42876e2b-1e96-418a-9284-824e8103d779.png)

After
![Screenshot 2022-08-10 at 10 38 43](https://user-images.githubusercontent.com/32130807/183882035-f941bb6d-240e-441e-b24b-c25b21e90978.png)
